### PR TITLE
Improve abstract detection

### DIFF
--- a/prototype/af_prototype/fuzzy_finding.py
+++ b/prototype/af_prototype/fuzzy_finding.py
@@ -62,8 +62,8 @@ def extract_abstract(pdf_file: Path, output: Path | None = None) -> str:
     section_order = [heading]
     sections = defaultdict(str)
 
-    # We attempt to find headings for sections by looking for a word on its own line.
-
+    # First heading defaults to "NONE"
+    # This section is where anything before an auto-detected section will show up
     heading = "NONE"
     section_order = [heading]
     sections = defaultdict(str)


### PR DESCRIPTION
It now works on a wider array of sections.
* It detects the `S P A C E   S E P A R A T E D`format that some journals use,
* Returns things that look like: `num. A Few Words` as a section
* And recognizes a few reserved keywords as the start of sections

It seems to work pretty well now, on the few inputs I've tested it on.

Also we are now always sending the subsequent section to GPT as well, just in case we are cutting the section off early.

A few tests:

```bash
$ ./af extract-sections ./inputs/theta-burst.pdf -vv
DEBUG - Writing section to inputs/theta-burst/0-NONE.txt
DEBUG - Writing section to inputs/theta-burst/1-abstract.txt
DEBUG - Writing section to inputs/theta-burst/2-introduction.txt
DEBUG - Writing section to inputs/theta-burst/3-methods.txt
DEBUG - Writing section to inputs/theta-burst/4-method.txt
DEBUG - Writing section to inputs/theta-burst/5-results.txt
DEBUG - Writing section to inputs/theta-burst/6-discussion.txt

$ ./af extract-sections ./inputs/RamaEtal17.pdf -vv
DEBUG - Writing section to inputs/RamaEtal17/0-NONE.txt
DEBUG - Writing section to inputs/RamaEtal17/1-introduction.txt
DEBUG - Writing section to inputs/RamaEtal17/2-methods.txt
DEBUG - Writing section to inputs/RamaEtal17/3-results.txt
DEBUG - Writing section to inputs/RamaEtal17/4-discussion.txt
DEBUG - Writing section to inputs/RamaEtal17/5-limitations.txt

$ ./af extract-sections ./inputs/agomt.pdf -vv
DEBUG - Writing section to inputs/agomt/0-NONE.txt
DEBUG - Writing section to inputs/agomt/1-abstract.txt
DEBUG - Writing section to inputs/agomt/2-method.txt
DEBUG - Writing section to inputs/agomt/3-results.txt
DEBUG - Writing section to inputs/agomt/4-discussion.txt
DEBUG - Writing section to inputs/agomt/5-limitations.txt
```