### PR TITLE
Improve local env and secret management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .*secret
 .*key
 .venv
+.env
 .cache
 credentials*.json
 __pycache__

--- a/generate_dotenv.py
+++ b/generate_dotenv.py
@@ -35,8 +35,6 @@ def copy_dev_env_vars(output: Path):
         if factory and (var := getattr(factory, "__self__", None)):
             if isinstance(var, (EnvVar, SecretFile)) and var.required:
                 secret_vars.append(var.env)
-            elif isinstance(var, SecretFile) and var.required:
-                secret_vars.append(var.env)
 
     print(f"Fetching the following variables from fly.io: {', '.join(secret_vars)}")
 

--- a/generate_dotenv.py
+++ b/generate_dotenv.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""
+Inspect the config for the application,
+retrieve the secrets as they are defined in fly.io,
+and create a file defining them locally
+"""
+
+from pathlib import Path
+import subprocess
+from dataclasses import fields
+from readable_af.config import Config, EnvVar, SecretFile
+
+
+def copy_dev_env_vars(output: Path):
+    """Fetch environment variables from fly.io."""
+    # Get all of the env variables from fly.io
+    try:
+        result = subprocess.run(
+            ["fly", "ssh", "console", "--app", "article-friend-dev", "-C", "env"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except subprocess.CalledProcessError as e:
+        print(f"Error: {e}")
+        print("The dev site for article friend may not be running at the moment.")
+        print(
+            "Try visiting https://article-friend-dev.fly.dev and then re-running this script."
+        )
+        return
+
+    secret_vars: list[str] = []
+    for field in fields(Config):
+        factory = field.default_factory
+        if factory and (var := getattr(factory, "__self__", None)):
+            if isinstance(var, (EnvVar, SecretFile)) and var.required:
+                secret_vars.append(var.env)
+            elif isinstance(var, SecretFile) and var.required:
+                secret_vars.append(var.env)
+
+    print(f"Fetching the following variables from fly.io: {', '.join(secret_vars)}")
+
+    env_lines = []
+    for line in result.stdout.splitlines():
+        if any(line.startswith(f"{var}=") for var in secret_vars):
+            env_lines.append(line.strip())
+
+    with output.open("w") as f:
+        for line in env_lines:
+            f.write(f"{line}\n")
+    print("Rendered secrets to ", output)
+
+
+if __name__ == "__main__":
+    output_path = Path(__file__).parent / ".env"
+    copy_dev_env_vars(output_path)

--- a/readable_af/config.py
+++ b/readable_af/config.py
@@ -1,77 +1,138 @@
 import dataclasses
+from functools import cache, cached_property
 import os
 from dataclasses import dataclass
 from pathlib import Path
 from typing import ClassVar
 
-_openai_api_key_file = Path(__file__).parent.parent / ".openai-key"
-_nounproject_api_key_file = Path(__file__).parent.parent / ".nounproject-key"
-_nounproject_secret_file = Path(__file__).parent.parent / ".nounproject-secret"
-_recaptcha_site_key_file = Path(__file__).parent.parent / ".recaptcha-site-key"
-_recaptcha_secret_key_file = Path(__file__).parent.parent / ".recaptcha-secret"
-_google_client_secrets_file = Path(__file__).parent.parent / "credentials.json"
+_HERE = Path(__file__).parent
+_DEFAULT_ENV_FILE = _HERE.parent / ".env"
 
 
-def _get_secret(env_var: str, secret_file: Path) -> str:
-    secret = os.getenv(env_var)
-    if not secret:
-        if secret_file.exists():
-            secret = secret_file.read_text().strip()
-        else:
-            raise ValueError(f"{env_var} not set")
-    return secret
+def _read_dotenv(env_var: str, file_path: Path = _DEFAULT_ENV_FILE) -> str:
+    """Read a specific environemnt variable from a .env file"""
+    if not file_path.exists():
+        raise FileNotFoundError(f"File {file_path} does not exist.")
+
+    with file_path.open("r") as f:
+        for line in f:
+            if line.startswith(env_var):
+                return line.split("=", 1)[1].strip().strip('"')
+    raise ValueError(f"{env_var} not found in {file_path}")
+
+
+@dataclass(frozen=True)
+class EnvVar:
+    """Container to hold a single config variable defined in the environment or a .env file."""
+
+    env: str
+    required: ClassVar[bool] = False
+
+    @cache
+    def get(self) -> str | None:
+        """Retrieve the value of the env var.
+        :returns: Value, or None if not set
+        """
+        env_value = os.getenv(self.env)
+        if env_value is not None:
+            return env_value
+        try:
+            return _read_dotenv(self.env)
+        except (FileNotFoundError, ValueError) as e:
+            if self.required:
+                raise e
+            return None
+
+
+@dataclass(frozen=True)
+class RequiredEnvVar(EnvVar):
+    """Overload of EnvVar that is required for the application to run."""
+
+    required: ClassVar[bool] = True
+
+    @cache
+    def get(self) -> str:
+        """Return the value of the env var, raising an exception if not set"""
+        value = super().get()
+        # This next line should never raise because 'required' is True above
+        assert value is not None, f"Required secret {self.env} is not set."
+        return value
+
+
+@dataclass
+class SecretFile:
+    """Holds a reference to config variable that must be written to a file."""
+
+    env: str  # An environment variable that may hold the file contents
+    file_path: Path  # The path to the file that will be created
+
+    # Required by default, until we have a need for an optional secret file
+    required: ClassVar[bool] = True
+
+    def get(self) -> Path:
+        """Get the path to a file containing the secret contents."""
+        if self.file_path.exists():
+            return self.file_path
+        contents = self.contents
+        with self.file_path.open("w") as f:
+            f.write(contents)
+        return self.file_path
+
+    @cached_property
+    def contents(self) -> str:
+        """Get the contents of the secret from env or file path."""
+        if self.file_path.exists():
+            return self.file_path.read_text().strip()
+        return RequiredEnvVar(self.env).get()
 
 
 @dataclass
 class Config:
+    """Define all configuration variables for the application here.
+
+    Class should be instatiated with `Config.get()` to avoid repeatedly reading from the environment.
+    """
+
     n_icons: int = 3
 
     openai_org_id: str = "org-byzsYSY4AKLquKGVxYWLjnOv"
 
-    @property
-    def google_client_secrets_file(self) -> Path:
-        if not _google_client_secrets_file.exists() or _google_client_secrets_file.stat().st_size == 0:
-            secret_json = os.getenv("CREDENTIALS_JSON")
-            assert secret_json is not None
-            with _google_client_secrets_file.open("w") as f:
-                f.write(secret_json)
-        return _google_client_secrets_file
+    google_client_secrets_file: Path = dataclasses.field(
+        default_factory=SecretFile(
+            "CREDENTIALS_JSON",
+            _HERE.parent.parent / "credentials.json",
+        ).get
+    )
+    openai_api_key: str = dataclasses.field(
+        default_factory=RequiredEnvVar("OPENAI_API_KEY").get
+    )
+    nounproject_api_key: str = dataclasses.field(
+        default_factory=RequiredEnvVar("NOUNPROJECT_API_KEY").get
+    )
+    nounproject_secret: str = dataclasses.field(
+        default_factory=RequiredEnvVar("NOUNPROJECT_SECRET").get
+    )
+    recapcha_site_key: str = dataclasses.field(
+        default_factory=RequiredEnvVar("RECAPTCHA_SITE_KEY").get
+    )
+    recapcha_secret: str = dataclasses.field(
+        default_factory=RequiredEnvVar("RECAPTCHA_SECRET").get
+    )
+    redis_host: str | None = dataclasses.field(
+        default_factory=EnvVar("REDIS_URL").get,
+    )
+    redis_password: str | None = dataclasses.field(
+        default_factory=EnvVar("REDIS_PASSWORD").get
+    )
 
-    @property
-    def openai_api_key(self) -> str:
-        return _get_secret("OPENAI_API_KEY", _openai_api_key_file)
-
-    @property
-    def nounproject_api_key(self) -> str:
-        return _get_secret("NOUNPROJECT_API_KEY", _nounproject_api_key_file)
-
-    @property
-    def nounproject_secret(self) -> str:
-        return _get_secret("NOUNPROJECT_SECRET", _nounproject_secret_file)
-
-    @property
-    def recapcha_site_key(self) -> str:
-        return _get_secret("RECAPTCHA_SITE_KEY", _recaptcha_site_key_file)
-
-    @property
-    def recapcha_secret(self) -> str:
-        return _get_secret("RECAPTCHA_SECRET", _recaptcha_secret_key_file)
-    
-    @property
-    def redis_host(self) -> str | None:
-        return os.getenv("REDIS_URL")
-    
-    @property
-    def redis_password(self) -> str | None:
-        return os.getenv("REDIS_PASSWORD")
-
-    instance: ClassVar["Config| None"] = None
+    _instance: ClassVar["Config| None"] = None
 
     def __post_init__(self):
-        Config.instance = self
+        Config._instance = self
 
     @classmethod
     def get(cls) -> "Config":
-        if cls.instance is None:
-            cls.instance = Config()
-        return cls.instance
+        """Retrieve the singleton instance of Config."""
+        if cls._instance is None:
+            cls._instance = Config()
+        return cls._instance

--- a/readable_af/config.py
+++ b/readable_af/config.py
@@ -10,7 +10,7 @@ _DEFAULT_ENV_FILE = _HERE.parent / ".env"
 
 
 def _read_dotenv(env_var: str, file_path: Path = _DEFAULT_ENV_FILE) -> str:
-    """Read a specific environemnt variable from a .env file"""
+    """Read a specific environment variable from a .env file"""
     if not file_path.exists():
         raise FileNotFoundError(f"File {file_path} does not exist.")
 


### PR DESCRIPTION
Cleans up local environment and secret management to make it easier to deal with moving forward.

* Define the secrets read from environment variables in a consistent and accessible way
* Allow the ability for env variables to be read from a single .env file instead of a host of different files
* Add a script which will retrieve the environment variables from the development version of articleFriend and automatically populate .env